### PR TITLE
✨ Checamos y utilizamos el token de seguridad

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,4 +10,4 @@ install:
 	cp --preserve ./src/geci-testmake /usr/local/bin
 
 tests: install
-	shellspec tests
+	shellspec --shell bash tests

--- a/src/geci-testmake
+++ b/src/geci-testmake
@@ -218,9 +218,3 @@ else
     exit 1
   fi
 fi
-
-function get_permission_from_tablero_API () {
-  URL="http://localhost:500/api/v1/login"
-  HTTP_CODE=$(curl --write-out "%{http_code}\n" --header "Authorization: ${TABLERO_API_SECRET_KEY}" --request POST "${URL}" --silent)
-  echo $HTTP_CODE
-}

--- a/src/geci-testmake
+++ b/src/geci-testmake
@@ -86,6 +86,24 @@ else
   ES_PHONY=1
   echo - Phony: $PHONY
 fi
+
+# Verifica que la variable de entorno <TABLERO_API_SECRET_KEY> se encuentre definida
+if [[ -z ${TABLERO_API_SECRET_KEY} ]];
+then
+    echo
+    echo
+    echo "La variable de entorno <TABLERO_API_SECRET_KEY> no esta definida"
+    echo "Fin del proceso."
+    echo "------------------------------------------------------------------"
+    exit 1
+else
+    echo
+    echo
+    echo "La variable de entorno <TABLERO_API_SECRET_KEY> esta definida,"
+    echo "Continuando con el proceso..."
+    echo "------------------------------------------------------------------"
+fi
+
 echo
 echo
 echo "Prepara directorio de trabajo:"
@@ -181,7 +199,7 @@ timestamp=$(date -Iseconds)&\
 es_make_exitoso=${ES_MAKE_EXISTOSO}&\
 es_phony=${ES_PHONY}&\
 existe_objetivo=${EXISTE_OBJETIVO}"
-  curl --location --request POST "$URL"
+  curl --header "Authorization: ${TABLERO_API_SECRET_KEY}" --location --request POST "${URL}"
 }
 
 if [ -s $RUTA_CLON/$OBJETIVO ]; then
@@ -200,3 +218,9 @@ else
     exit 1
   fi
 fi
+
+function get_permission_from_tablero_API () {
+  URL="http://localhost:500/api/v1/login"
+  HTTP_CODE=$(curl --write-out "%{http_code}\n" --header "Authorization: ${TABLERO_API_SECRET_KEY}" --request POST "${URL}" --silent)
+  echo $HTTP_CODE
+}

--- a/tests/tablero-api-secret-key_spec.sh
+++ b/tests/tablero-api-secret-key_spec.sh
@@ -1,0 +1,19 @@
+Describe 'geci-testmake'
+  It 'Requires TABLERO_API_SECRET_KEY'
+    unset TABLERO_API_SECRET_KEY
+    When call src/geci-testmake hola mundo
+    The line 8 of stdout should equal 'La variable de entorno <TABLERO_API_SECRET_KEY> no esta definida'
+    The status should be failure
+  End
+
+  Mock mkdir
+    exit 0
+  End
+
+  It 'Accepts TABLERO_API_SECRET_KEY'
+    export TABLERO_API_SECRET_KEY=dummy_key
+    When call src/geci-testmake hola mundo
+    The line 8 of stdout should equal 'La variable de entorno <TABLERO_API_SECRET_KEY> esta definida,'
+    The status should be failure
+  End
+End


### PR DESCRIPTION
Queremos proteger nuestro tablero API de cualquier uso externo no planeado,
Para esto el objetivo es agregar un token de seguridad en nuestro testmake para que al final los resultados puedan llegar o no a nuestro tablero dependiendo de este token.

Instrucciones:
1. Clonar el repo y cambiar de rama
2. Ejecutar `make install`  para instalar esta versión del testmake
3. Echar a andar el hola mundo `geci-testmake hola mundo`
4. Observar el resultado

__NOTA__:
La primera vez el reporte fallará, esto porque lo más seguro es que no esté definida y cargada esta variable
`$TABLERO_API_SECRET_KEY` en el `~/.vault/.secrets`.
Por favor definirla con un valor aleatorio, cargala con `source ~/.vault/.secrets` y probar de nuevo la generación del reporte para verificar los cambios

Para finalizar, vuelve a la rama master y reinstala la versión de testmake original para no tener problemas después.